### PR TITLE
Fix autovalidate not work with special character

### DIFF
--- a/lib/unova_form/builder.rb
+++ b/lib/unova_form/builder.rb
@@ -10,7 +10,12 @@ module UnovaForm
   class Builder < ActionView::Helpers::FormBuilder
     AUTOVALIDATE_JS_STRING = <<~JS.gsub(/\s+/, " ").strip.freeze
       let s=this;
-      for (const [r, m] of Object.entries(JSON.parse(s.dataset.patternMessages)))
+      for (const [r, m] of Object.entries(JSON.parse(s.dataset.patternMessages))) {
+        // Ensure html encoded data is decoded (Rails encode data from builder for security)
+        let txt = document.createElement("textarea");
+        txt.innerHTML = r;
+        r = txt.value;
+        // end
         if (!(new RegExp(r)).test(s.value)){ if(s.validationMessage !== m) {
           s.setCustomValidity(m); s.reportValidity();} return;
         } if(s.validity.customError){
@@ -20,6 +25,7 @@ module UnovaForm
             s.form.submit()
           } return;
         }
+      }
     JS
     delegate :content_tag, :tag, :safe_join, :rails_direct_uploads_url, :capture, :concat, to: :@template
 

--- a/lib/unova_form/builder.rb
+++ b/lib/unova_form/builder.rb
@@ -208,6 +208,7 @@ module UnovaForm
     end
 
     private
+
       # @param [String | NilClass] label
       # @param [Hash] attrs
       def render_field_using_attrs(label, attrs)
@@ -216,17 +217,17 @@ module UnovaForm
         attrs.delete(:options)
 
         case attrs[:type]
-        when :file
-          return file_field label,
-                            value: current_file_value,
-                            value_url: current_file_value_url,
-                            accept: current_accepted_files&.join(","),
-                            value_type: current_file_type,
-                            **attrs.except(:value, :placeholder, :type)
-        when :checkbox
-          return boolean_field label, checked: current_value == true, **attrs.except(:value)
-        else
-          nil
+          when :file
+            return file_field label,
+                              value: current_file_value,
+                              value_url: current_file_value_url,
+                              accept: current_accepted_files&.join(","),
+                              value_type: current_file_type,
+                              **attrs.except(:value, :placeholder, :type)
+          when :checkbox
+            return boolean_field label, checked: current_value == true, **attrs.except(:value)
+          else
+            nil
         end
 
         # import minimum / maximum value from length validator or numericality validator
@@ -306,9 +307,9 @@ module UnovaForm
         # @type [String, NilClass] pattern
         # import and concat patterns from format validators
         pattern = case format_validators
-        when Array then "#{format_validators.map { |v| validator_to_html_pattern(v, pattern_messages) }.join}.*"
-        when Hash then "#{validator_to_html_pattern(format_validators, pattern_messages)}.*"
-        else return ["", "{}"]
+          when Array then "#{format_validators.map { |v| validator_to_html_pattern(v, pattern_messages) }.join}.*"
+          when Hash then "#{validator_to_html_pattern(format_validators, pattern_messages)}.*"
+          else return ["", "{}"]
         end
 
         [pattern.gsub("\"", "\\\""), pattern_messages.to_json]
@@ -389,13 +390,13 @@ module UnovaForm
         # noinspection RubyMismatchedArgumentType False positive
         if [Proc, Array].include?(current_field.options.class)
           return case current_field.options.try(:arity) # arity is the number of arguments, if arity is nil, it's a array
-          when 0 then current_field.options.try(:call)
-          when 1 then current_field.options.try(:call, current_value)
-          when 2 then current_field.options.try(:call, current_value, object)
-          when nil then current_field.options.try(:map) do |h|
-            h.deep_dup.symbolize_keys.tap { |nh| nh[:selected] = nh[:value] == current_value }
-          end
-          else nil
+            when 0 then current_field.options.try(:call)
+            when 1 then current_field.options.try(:call, current_value)
+            when 2 then current_field.options.try(:call, current_value, object)
+            when nil then current_field.options.try(:map) do |h|
+              h.deep_dup.symbolize_keys.tap { |nh| nh[:selected] = nh[:value] == current_value }
+            end
+            else nil
           end
         end
         nil
@@ -418,11 +419,11 @@ module UnovaForm
 
       def file_type_from_method_name
         case @current_method.to_s
-        when /video/, /mp4/, /avi/, /mov/, /mkv/, /webm/, /wmv/, /flv/, /ogv/, /gifv/ then :video
-        when /avatar/, /image/, /img/, /picture/, /photo/, /jpg/, /png/, /bitmap/, /gif/, /svg/, /webp/ then :img
-        when /sound/, /audio/, /mp3/, /music/, /song/, /flac/, /wav/, /ogg/, /oga/, /opus/, /m4a/, /aac/, /wma/, /alac/, /aiff/ then :audio
-        else
-          :other
+          when /video/, /mp4/, /avi/, /mov/, /mkv/, /webm/, /wmv/, /flv/, /ogv/, /gifv/ then :video
+          when /avatar/, /image/, /img/, /picture/, /photo/, /jpg/, /png/, /bitmap/, /gif/, /svg/, /webp/ then :img
+          when /sound/, /audio/, /mp3/, /music/, /song/, /flac/, /wav/, /ogg/, /oga/, /opus/, /m4a/, /aac/, /wma/, /alac/, /aiff/ then :audio
+          else
+            :other
         end
       end
 
@@ -431,10 +432,10 @@ module UnovaForm
         type = current_accepted_files || object.try(@current_method).try(:content_type) || object.try(@current_method).try(:blob).try(:content_type)
         type = type[0].to_s if type.is_a?(Array)
         case type
-        when /^image/ then :img
-        when /^video/ then :video
-        when /^audio/ then :audio
-        else file_type_from_method_name
+          when /^image/ then :img
+          when /^video/ then :video
+          when /^audio/ then :audio
+          else file_type_from_method_name
         end
       end
 


### PR DESCRIPTION
See issue RD7198

When rails generate pattern and pattern-message attribute, it transform to html safe string to avoid XSS. 
It's preferred to keep this feature and just convert HTML Safe to Text in JS.

```html
<input .... pattern="[!@#$%^&*()_+\-=\[\]{};':\"\\|,.<>/?]" />
```

result string

```javascript
"[!\\u0026quot;\#$%\\u0026'()*+,-./:;\\u003c=\\u003e?@[\\\\]^_`{|}~]" // Like this
```